### PR TITLE
Update renovate config

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
 		"build": "vite build",
 		"package": "svelte-kit package",
 		"preview": "vite preview",
-		"prepare": "svelte-kit sync && husky install",
+		"prepare": "husky install",
 		"test": "playwright test --update-snapshots",
 		"check": "svelte-check --tsconfig ./tsconfig.json",
 		"lint": "prettier --check --plugin-search-dir=. . && eslint .",

--- a/renovate.json
+++ b/renovate.json
@@ -3,8 +3,17 @@
 	"extends": ["config:base", "schedule:earlyMondays"],
 	"packageRules": [
 		{
-			"matchUpdateTypes": ["minor", "patch", "pin", "digest"],
+			"matchPackagePatterns": ["*"],
+			"matchUpdateTypes": ["minor", "patch"],
+			"groupName": "all non-major dependencies",
+			"groupSlug": "all-minor-patch",
 			"automerge": true
+		},
+		{
+			"matchPackagePatterns": ["*"],
+			"matchUpdateTypes": ["major"],
+			"groupName": "all major dependencies",
+			"groupSlug": "all-major-patch"
 		}
 	],
 	"platformAutomerge": true


### PR DESCRIPTION
## Why

Original renovate config creates too many merge requests. Now group all minor & patch updates and exclude major updates from auto-merge.

## What

- Remove `svelte-kit sync`
- Update renovate config